### PR TITLE
Update docker automated label on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud Foundry Bosh Cli deployed using docker [![Docker Automated buil](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg?style=plastic)](https://hub.docker.com/r/orangecloudfoundry/orange-cf-bosh-cli/)
+# Cloud Foundry Bosh Cli deployed using docker [![Docker Automated build](https://img.shields.io/docker/automated/orangecloudfoundry/orange-cf-bosh-cli.svg?style=plastic)](https://hub.docker.com/r/orangecloudfoundry/orange-cf-bosh-cli/)
 
 The `cf-bosh-cli` project helps you to deploy bosh cli and associated tools through docker.
 


### PR DESCRIPTION
The existing `docker automated` label was using the wrong docker repository handler (`jrottenberg/ffmpeg` instead of `orangecloudfoundry/orange-cf-bosh-cli`).