### PR TITLE
Fix ruby and ytt installation. Introduce a minimal image cli checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:18.04 as orange_cli
 USER root
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -27,14 +27,13 @@ ENV BBR_VERSION="1.8.1" \
     JQ_VERSION="1.6" \
     K14S_KAPP_VERSION="0.34.0" \
     K14S_KLBD_VERSION="0.27.0" \
-    K14S_YTT_VERSION="0.34.0" \
+    K14S_YTT_VERSION="0.30.0" \
     K9S_VERSION="0.23.3" \
     KUBECTL_VERSION="1.18.8" \
     KUSTOMIZE_VERSION="3.8.6" \
     MYSQL_SHELL_VERSION="8.0.21-1" \
     RUBY_BUNDLER_VERSION="1.17.3" \
-    RUBY_VERSION="2.6" \
-    RUBY_PATH_VERSION="2.6.3" \
+    RUBY_VERSION="2.6.5" \
     SHIELD_VERSION="8.7.3" \
     SPRUCE_VERSION="1.27.0" \
     SVCAT_VERSION="0.3.0" \
@@ -43,9 +42,9 @@ ENV BBR_VERSION="1.8.1" \
     VELERO_VERSION="1.4.0"
 
 #--- Set ruby env for COA
-ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_PATH_VERSION}/bin:/usr/local/rvm/gems/ruby-${RUBY_PATH_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_PATH_VERSION}/bin:${PATH}" \
-    GEM_HOME="/usr/local/rvm/gems/ruby-${RUBY_PATH_VERSION}" \
-    GEM_PATH="/usr/local/rvm/gems/ruby-${RUBY_PATH_VERSION}:/usr/local/rvm/gems/ruby-${RUBY_PATH_VERSION}@global"
+ENV PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}/bin:/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global/bin:/usr/local/rvm/rubies/ruby-${RUBY_VERSION}/bin:${PATH}" \
+    GEM_HOME="/usr/local/rvm/gems/ruby-${RUBY_VERSION}" \
+    GEM_PATH="/usr/local/rvm/gems/ruby-${RUBY_VERSION}:/usr/local/rvm/gems/ruby-${RUBY_VERSION}@global"
 
 ADD bosh-cli/* /tmp/bosh-cli/
 
@@ -155,3 +154,16 @@ RUN printf '\n=====================================================\n Install sy
 #--- Launch supervisord daemon
 CMD /usr/local/bin/supervisord.sh
 EXPOSE 22
+
+
+# test image
+# ============================================================================
+FROM orange_cli AS tests
+ADD tests/* /tmp/tests/
+RUN /tmp/tests/check-available-cli-from-usr-bin.sh
+RUN /tmp/tests/check-available-cli-from-usr-local-bin.sh
+RUN /tmp/tests/check-available-cli-from-other-locations.sh
+
+# export runtime image
+# ============================================================================
+FROM orange_cli

--- a/tests/check-available-cli-from-other-locations.sh
+++ b/tests/check-available-cli-from-other-locations.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+echo "Running $0"
+
+echo "Ensure ruby is available"
+ruby -e 'puts "Ruby is installed"'

--- a/tests/check-available-cli-from-usr-bin.sh
+++ b/tests/check-available-cli-from-usr-bin.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+echo "Running $0"
+echo "Ensure expected cli are available (from /usr/bin)"
+mysqlsh --version

--- a/tests/check-available-cli-from-usr-local-bin.sh
+++ b/tests/check-available-cli-from-usr-local-bin.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "Running $0"
+
+set -e
+echo "Ensure expected cli are available (from /usr/local/bin)"
+set -x
+bbr --version
+bosh --version
+cf --version
+cf7 --version
+chardetect --version
+credhub --version
+fly --version
+go3fr --version
+helm version
+jq --version
+k9s version --short
+kapp version
+klbd --version
+kubectl version --client --short
+kustomize version --short
+mc --version
+pip --version
+pip2 --version
+pip2.7 --version
+pynsxv --help >/dev/null
+shield --version
+spruce --version
+svcat --help >/dev/null
+tabulate --help >/dev/null
+terraform --version
+velero version --client-only
+ytt --version
+set +x
+
+echo "Check complete"


### PR DESCRIPTION
Changes proposed in this pull-request:
- use an existing version of ytt
- merge RUBY_VERSION and RUBY_PATH_VERSION to avoid inconsistency
- add minimal UT to ensure each expected cli can be executed