### PR TITLE
log-K8S now configures svcat completion

### DIFF
--- a/bosh-cli/log-k8s.sh
+++ b/bosh-cli/log-k8s.sh
@@ -82,3 +82,6 @@ if [ ${flagError} = 0 ] ; then
 fi
 token="$(kubectl describe secret -n kube-system $(kubectl get secret -n kube-system | grep admin | awk '{print $1}') | grep "token:" | sed -e "s+token: *++g")"
 printf "\n%bk8s token:%b\n${token}\n" "${YELLOW}${REVERSE}" "${STD}"
+
+# Setting up svcat completion which requires the kube config to be present
+source <(svcat completion bash)


### PR DESCRIPTION
log-K8S now configures svcat completion which depends on kube config

Otherwise fails when following command is run as root without kubeconfig (would also likely fail in DockerFile):

```
$ /usr/local/bin/svcat completion bash > /etc/bash_completion.d/svcat 
Error: could not get Kubernetes config for context "": invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```