### PR TITLE
Generalize flux trace to all resources

### DIFF
--- a/bosh-cli/profile
+++ b/bosh-cli/profile
@@ -104,28 +104,17 @@ plugin:
     args:
     - -c
     - "flux reconcile kustomization --context $CONTEXT -n $NAMESPACE $NAME | less"
-  trace-hr:
-    shortCut: t
+  flux-trace:
+    shortCut: Shift-A
     confirm: false
     description: Flux trace
     scopes:
-    - helmreleases
+    - all
     command: sh
     background: false
     args:
     - -c
-    - "flux trace $NAME --kind helmrelease --api-version helm.toolkit.fluxcd.io/v2beta1 --context $CONTEXT -n $NAMESPACE $NAME | less"
-  trace-ks:
-    shortCut: t
-    confirm: false
-    description: Flux trace
-    scopes:
-    - kustomizations
-    command: sh
-    background: false
-    args:
-    - -c
-    - "flux trace $NAME --kind kustomization --api-version kustomize.toolkit.fluxcd.io/v1beta2 --context $CONTEXT -n $NAMESPACE $NAME | less"
+    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed s/s$//g` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"
 EOF
 
 #--- Copy bash user configuration

--- a/bosh-cli/profile
+++ b/bosh-cli/profile
@@ -114,7 +114,7 @@ plugin:
     background: false
     args:
     - -c
-    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed s/s$//g` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"
+    - "flux trace $NAME --kind `echo $RESOURCE_NAME | sed -E 's/(s|es)$//g'` --api-version $RESOURCE_GROUP/$RESOURCE_VERSION --namespace $NAMESPACE $NAME | less"
 EOF
 
 #--- Copy bash user configuration


### PR DESCRIPTION
Note that t shortcut is conflicting with cronjobs trigger, so shift-A is used insteaf