### PR TITLE
Add k9s shortcut t to trigger argoworkflow from a template

### DIFF
--- a/bosh-cli/profile
+++ b/bosh-cli/profile
@@ -115,6 +115,16 @@ plugin:
     args:
     - -c
     - "flux reconcile kustomization --context $CONTEXT -n $NAMESPACE $NAME | less"
+  submit-argoworkflow-template:
+    shortCut: t
+    confirm: true
+    description: Submit argo workflow
+    scopes:
+    - workflowtemplates
+    command: sh
+    args:
+    - -c
+    - "argo submit --from workflowtemplate/$NAME | less"
 EOF
 
 #--- Copy bash user configuration

--- a/bosh-cli/profile
+++ b/bosh-cli/profile
@@ -124,7 +124,7 @@ plugin:
     command: sh
     args:
     - -c
-    - "argo submit --from workflowtemplate/$NAME | less"
+    - "argo submit --from workflowtemplate/$NAME -n $NAMESPACE | less"
 EOF
 
 #--- Copy bash user configuration


### PR DESCRIPTION
To test:  
* go to k3s-sandbox, in namespace 22-argo-workflows 
* display workflowtemplates crds
* select 'kuttl-template'
* press t
* record the name of the submitted workflow (eg. kuttl-template-fhnch)
* display workflow crds
* select kuttl-template-fhnch
* press d to display workflow status. 
* to access logs:
* display pod
* select the pod matching the workflow name (e.g kuttl-template-fhnch)
* display logs (l)