### PR TITLE
Fix conflicting k9s short cut

### DIFF
--- a/tools/k9s-plugins.yml
+++ b/tools/k9s-plugins.yml
@@ -44,7 +44,7 @@ plugin:
       - -c
       - "kubectl get kustomizations.kustomize.toolkit.fluxcd.io --all-namespaces --context $CONTEXT -o json | jq -r '.items[] | select(.spec.suspend==true) | [.metadata.name,.spec.suspend] | @tsv' |& less"
   kapp-inspect:
-    shortCut: Shift-Z
+    shortCut: Shift-I
     description: Kapp inspect
     scopes:
       - app


### PR DESCRIPTION
Shift-Z was assigned to both kapp-inspect and kctrl-app-kick
kapp-inspect is now assigned Shift-I